### PR TITLE
Bump csv-parse and csv

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -618,33 +618,30 @@
       "dev": true
     },
     "csv": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/csv/-/csv-1.2.1.tgz",
-      "integrity": "sha1-UjHt/BxxUlEuxFeBB2p6l/9SXAw=",
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/csv/-/csv-6.3.3.tgz",
+      "integrity": "sha512-TuOM1iZgdDiB6IuwJA8oqeu7g61d9CU9EQJGzCJ1AE03amPSh/UK5BMjAVx+qZUBb/1XEo133WHzWSwifa6Yqw==",
       "requires": {
-        "csv-generate": "1.1.2",
-        "csv-parse": "1.3.3",
-        "csv-stringify": "1.1.2",
-        "stream-transform": "0.2.2"
+        "csv-generate": "^4.2.8",
+        "csv-parse": "^5.5.0",
+        "csv-stringify": "^6.4.2",
+        "stream-transform": "^3.2.8"
       }
     },
     "csv-generate": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-1.1.2.tgz",
-      "integrity": "sha1-7GsA7a7W5ZrZwgWC9MNk4osUYkA="
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-4.2.8.tgz",
+      "integrity": "sha512-qQ5CUs4I58kfo90EDBKjdp0SpJ3xWnN1Xk1lZ1ITvfvMtNRf+jrEP8tNPeEPiI9xJJ6Bd/km/1hMjyYlTpY42g=="
     },
     "csv-parse": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-1.3.3.tgz",
-      "integrity": "sha1-0c/YdDwvhJoKuy/VRNtWaV0ZpJA="
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.5.0.tgz",
+      "integrity": "sha512-RxruSK3M4XgzcD7Trm2wEN+SJ26ChIb903+IWxNOcB5q4jT2Cs+hFr6QP39J05EohshRFEvyzEBoZ/466S2sbw=="
     },
     "csv-stringify": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-1.1.2.tgz",
-      "integrity": "sha1-d6QVJlgbzjOA8SsA18W7rHDIK1g=",
-      "requires": {
-        "lodash.get": "4.4.2"
-      }
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.4.2.tgz",
+      "integrity": "sha512-DXIdnnCUQYjDKTu6TgCSzRDiAuLxDjhl4ErFP9FGMF3wzBGOVMg9bZTLaUcYtuvhXgNbeXPKeaRfpgyqE4xySw=="
     },
     "date-extended": {
       "version": "0.0.6",
@@ -2674,9 +2671,9 @@
       }
     },
     "stream-transform": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-0.2.2.tgz",
-      "integrity": "sha1-dYZ0h/SVKPi/HYJJllh1PQLfeDg="
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-3.2.8.tgz",
+      "integrity": "sha512-NUx0mBuI63KbNEEh9Yj0OzKB7iMOSTpkuODM2G7By+TTVihEIJ0cYp5X+pq/TdJRlsznt6CYR8HqxexyC6/bTw=="
     },
     "streamifier": {
       "version": "0.1.1",
@@ -2688,11 +2685,6 @@
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
       "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
     },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-    },
     "string-extended": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/string-extended/-/string-extended-0.0.8.tgz",
@@ -2703,6 +2695,11 @@
         "extended": "0.0.6",
         "is-extended": "0.0.10"
       }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "strip-eof": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 	"homepage": "https://github.com/riddhishikha15/tranning-csv-upload#readme",
 	"dependencies": {
 		"body-parser": "^1.18.2",
-		"csv": "^1.1.1",
+		"csv": "^6.3.3",
 		"express": "^4.16.2",
 		"express-fileupload": "^0.4.0",
 		"express-rate-limit": "^2.11.0",


### PR DESCRIPTION
Bumps [csv-parse](https://github.com/adaltas/node-csv/tree/HEAD/packages/csv-parse) to 5.5.0 and updates ancestor dependency [csv](https://github.com/adaltas/node-csv/tree/HEAD/packages/csv). These dependencies need to be updated together.


Updates `csv-parse` from 1.3.3 to 5.5.0
- [Changelog](https://github.com/adaltas/node-csv/blob/master/packages/csv-parse/CHANGELOG.md)
- [Commits](https://github.com/adaltas/node-csv/commits/csv-parse@5.5.0/packages/csv-parse)

Updates `csv` from 1.2.1 to 6.3.3
- [Changelog](https://github.com/adaltas/node-csv/blob/master/packages/csv/CHANGELOG.md)
- [Commits](https://github.com/adaltas/node-csv/commits/csv@6.3.3/packages/csv)

---
updated-dependencies:
- dependency-name: csv-parse dependency-type: indirect
- dependency-name: csv dependency-type: direct:production ...