### PR TITLE
Bump deep-extend and rc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2133,13 +2133,13 @@
     "rc": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.5.tgz",
-      "integrity": "sha1-J1zWh/bjs2zHVrqibf7oCnkDAf0=",
+      "integrity": "sha512-W9DW3KA9AMPhH/9ptNc+yy6BgL8xSAJINMdA8NRi3XKbb3FFUp/szBcNb4BdV3VAma8CinXnWxlrPjP5tEGBug==",
       "dev": true,
       "requires": {
-        "deep-extend": "0.4.2",
-        "ini": "1.3.5",
-        "minimist": "1.2.0",
-        "strip-json-comments": "2.0.1"
+        "deep-extend": "~0.4.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
       }
     },
     "readable-stream": {
@@ -2688,11 +2688,6 @@
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
       "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
     },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-    },
     "string-extended": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/string-extended/-/string-extended-0.0.8.tgz",
@@ -2703,6 +2698,11 @@
         "extended": "0.0.6",
         "is-extended": "0.0.10"
       }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "strip-eof": {
       "version": "1.0.0",


### PR DESCRIPTION
Bumps [deep-extend](https://github.com/unclechu/node-deep-extend) and [rc](https://github.com/dominictarr/rc). These dependencies needed to be updated together.

Updates `deep-extend` from 0.4.2 to 0.6.0
- [Changelog](https://github.com/unclechu/node-deep-extend/blob/master/CHANGELOG.md)
- [Commits](https://github.com/unclechu/node-deep-extend/compare/v0.4.2...v0.6.0)

Updates `rc` from 1.2.5 to 1.2.8
- [Commits](https://github.com/dominictarr/rc/commits)

---
updated-dependencies:
- dependency-name: deep-extend dependency-type: indirect
- dependency-name: rc dependency-type: indirect ...